### PR TITLE
Update to main camera position

### DIFF
--- a/PixelDev Game/Assets/Art/Scenes/Background Base.unity
+++ b/PixelDev Game/Assets/Art/Scenes/Background Base.unity
@@ -184,7 +184,7 @@ Camera:
   far clip plane: 1000
   field of view: 60
   orthographic: 1
-  orthographic size: 6.0992193
+  orthographic size: 6.0010076
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
@@ -209,7 +209,7 @@ Transform:
   m_GameObject: {fileID: 360913798}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 44.44, y: 5.18, z: -10}
+  m_LocalPosition: {x: -6.1, y: 5.7, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []


### PR DESCRIPTION

<img width="832" alt="Screen Shot 2024-04-19 at 3 02 43 PM" src="https://github.com/IsaacP355/PixelDev/assets/113059638/6204d067-7171-488f-bed1-b97fd8731870">
Changing main camera position to a better starting scene for character movement development. This new display has more room for our character to move, run, and jump.